### PR TITLE
Add support for binomials in interpolateRoots

### DIFF
--- a/lib/PrimeField.ts
+++ b/lib/PrimeField.ts
@@ -950,8 +950,18 @@ function fastFT(values: readonly bigint[], roots: readonly bigint[], depth: numb
     const step = 1 << depth;
     const resultLength = roots.length / step;
 
+    if (resultLength == 2) {
+        const result = new Array<bigint>(2);
+        for (let i = 0; i < 2; i++) {
+            let last = values[offset] * roots[0];
+            last += values[offset + step] * roots[i * step];
+            result[i] = F.mod(last);
+        }
+        return result;
+    }
+
     // if only 4 values left, use simple FT
-    if (resultLength <= 4) {
+    if (resultLength == 4) {
         const result = new Array<bigint>(4);
         for (let i = 0; i < 4; i++) {
             let last = values[offset] * roots[0];

--- a/tests/PrimeField.spec.ts
+++ b/tests/PrimeField.spec.ts
@@ -1214,6 +1214,8 @@ describe('PrimeField;', () => {
             let fp: JsVector;
 
             [
+                [1n, 18446744069414584320n],
+
                 [2n,  1n,  2n, 3n],
                 [-2n, 1n, -2n, 3n],
 


### PR DESCRIPTION
Previously, passing a two-element Vector to interpolateRoots would throw an error because it attempted to add `undefined` to a `BigInt` due to indexing off the end of the values and roots arrays.

Thanks!